### PR TITLE
feat: Update copyright year 2024 & css fixes [main].

### DIFF
--- a/app/courses/[course]/(chapters)/[chapter]/page.tsx
+++ b/app/courses/[course]/(chapters)/[chapter]/page.tsx
@@ -280,7 +280,7 @@ const Chapter = async ({ params }: Props) => {
 			<div className="grid h-fit 2xl:col-span-1 2xl:col-start-2">
 				<Blog markdown={chapter?.contentFiltered} />
 			</div>
-			<div className="2xl:col-span-1 2xl:col-start-3 row-span-2 row-start-1 hidden sm:block pl-0 2xl:pl-4">
+			<div className="2xl:col-span-1 2xl:col-start-3 row-span-3 row-start-1 hidden sm:block pl-0 2xl:pl-4">
 				<div className="w-10 grid gap-8 sticky top-[40%]">
 					<a
 						href={`https://twitter.com/intent/tweet?url=https://akash.cx/courses/${params.course}/${params.chapter}&text=${chapter.title}`}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -165,7 +165,7 @@ const footer = ({ footer }: FooterProps) => {
             mt-3"
 			>
 				<p className="text-center text-lg copyright">
-					Copyright © 2023 Akash Aman{" "}
+					Copyright © 2024 Akash Aman{" "}
 					<i className="md:inline copyright not-italic hidden">|</i>{" "}
 					<br className="block md:hidden" />
 					<Link href="/terms">Terms & Conditions </Link>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -273,7 +273,7 @@ const Navigation = ({ nav }: NavigationProps) => {
 				mt-3"
 					>
 						<p className="text-center text-lg copyright">
-							Copyright © 2023 Akash Aman{" "}
+							Copyright © 2024 Akash Aman{" "}
 							<i className="md:inline copyright hidden">|</i>{" "}
 							<br className="block md:hidden" />
 							<Link href="/terms">Terms & Conditions </Link>


### PR DESCRIPTION
This pull request includes changes to the layout and copyright year updates across multiple files. The most important changes are as follows:

Layout adjustments:

* `app/courses/[course]/(chapters)/[chapter]/page.tsx`: Modified the grid layout for the chapter page to span three rows instead of two for better visual alignment. ([app/courses/[course]/(chapters)/[chapter]/page.tsxL283-R283](diffhunk://#diff-aee0c0e29ca65c305e138bd6227e02f36be756ad836857e962a42c111e7d556bL283-R283))

Copyright updates:

* [`components/footer.tsx`](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L168-R168): Updated the copyright year from 2023 to 2024.
* [`components/navigation.tsx`](diffhunk://#diff-87965675eb054932993012ea135fb551085d338e8ddcf7f480faf1ad2481286cL276-R276): Updated the copyright year from 2023 to 2024.